### PR TITLE
Use structure for baobzi parameterization

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,13 +259,15 @@ matlab -batch simple2d
 program main
   use baobzi
   implicit none
-  real(kind=c_double) :: center(2), half_length(2), tol, dummy
+  real(kind=c_double) :: center(2), half_length(2), tol
   real(kind=c_double) :: x(2)
+  real(kind=c_double), target :: scale_factor
   type(c_ptr) :: func_approx
   character(len=64) :: fname
   type(baobzi_input_t) :: input
 
   input%func = c_funloc(testfun)
+  input%data = c_loc(scale_factor)
   input%dim = 2
   input%order = 6
   input%tol = 1E-8
@@ -277,23 +279,23 @@ program main
   fname = trim(adjustl('fortran.baobzi'))//char(0)
 
   func_approx = baobzi_init(input, center, half_length)
-  print *, baobzi_eval(func_approx, x) - testfun(x, dummy)
+  print *, baobzi_eval(func_approx, x) - testfun(x, scale_factor)
 
   call baobzi_save(func_approx, fname)
   func_approx = baobzi_free(func_approx)
 
   func_approx = baobzi_restore(fname)
-  print *, baobzi_eval(func_approx, x) - testfun(x, dummy)
+  print *, baobzi_eval(func_approx, x) - testfun(x, scale_factor)
 
 contains
-  function testfun (x, data) bind(c) result(y)
+  function testfun (x, scale_factor) bind(c) result(y)
     use, intrinsic :: iso_c_binding
     implicit none
     real(kind=c_double), dimension(*) :: x
-    real(kind=c_double) :: data
+    real(kind=c_double) :: scale_factor
     real(kind=c_double) :: y
 
-    y = x(1) * x(2)
+    y = scale_factor * x(1) * x(2)
   end function testfun
 
 end program main

--- a/examples/baobzi_timing.c
+++ b/examples/baobzi_timing.c
@@ -7,7 +7,10 @@
 #include <stdlib.h>
 
 double testfun_1d(const double *x, const void *data) { return log(x[0]); }
-double testfun_2d(const double *x, const void *data) { return exp(cos(5.0 * x[0]) * sin(5.0 * x[1])); }
+double testfun_2d(const double *x, const void *data) {
+    const double scale_factor = *(double *)data;
+    return scale_factor * exp(cos(5.0 * x[0]) * sin(5.0 * x[1]));
+}
 double testfun_2d_2(const double *x, const void *data) {
     return exp(x[0] + 2 * sin(x[1])) * (x[0] * x[0] + log(2 + x[1]));
 }
@@ -99,18 +102,20 @@ int main(int argc, char *argv[]) {
         x[i] = ((double)rand()) / RAND_MAX;
 
     {
-        baobzi_input_t input;
+        double scale_factor = 1.5;
+        baobzi_input_t input = baobzi_input_default;
         input.dim = 2;
         input.order = 6;
         input.func = testfun_2d;
         input.tol = 1E-10;                                   // Maximum relative error target
+        input.data = &scale_factor;
         const double hl[2] = {1.0, 1.0};                     // half the length of the domain in each dimension
         const double center[2] = {hl[0] + 0.5, hl[1] + 2.0}; // center of the domain
         test_func(&input, x, hl, center, n_points, n_runs);
     }
 
     {
-        baobzi_input_t input;
+        baobzi_input_t input = baobzi_input_default;
         input.dim = 3;
         input.order = 6;
         input.tol = 1E-12;

--- a/examples/baobzi_timing.cpp
+++ b/examples/baobzi_timing.cpp
@@ -8,7 +8,10 @@
 using aligned_vector = std::vector<double, Eigen::aligned_allocator<double>>;
 
 double testfun_1d(const double *x, const void *data) { return log(x[0]); }
-double testfun_2d(const double *x, const void *data) { return exp(cos(5.0 * x[0]) * sin(5.0 * x[1])); }
+double testfun_2d(const double *x, const void *data) {
+    const double scale_factor = *(double *)data;
+    return scale_factor * exp(cos(5.0 * x[0]) * sin(5.0 * x[1]));
+}
 double testfun_2d_2(const double *x, const void *data) {
     return exp(x[0] + 2 * sin(x[1])) * (x[0] * x[0] + log(2 + x[1]));
 }
@@ -92,10 +95,11 @@ int main(int argc, char *argv[]) {
         Eigen::Vector2d hl{1.0, 1.0};
         Eigen::Vector2d center2d = hl + Eigen::Vector2d{0.5, 2.0};
         aligned_vector x_2d_transformed(n_points * 2);
+        double scale_factor = 1.5;
         baobzi_input_t input;
         input.dim = 2;
         input.order = 6;
-        input.data = nullptr;
+        input.data = &scale_factor;
         input.tol = 1E-8;
         input.func = testfun_2d_2;
 
@@ -103,7 +107,7 @@ int main(int argc, char *argv[]) {
             for (int j = 0; j < 2; ++j)
                 x_2d_transformed[i + j] = hl[j] * (2.0 * x[i + j] - 1.0) + center2d[j];
 
-        baobzi::Function<2, 8> func_approx_2d(&input, center2d.data(), hl.data());
+        baobzi::Function<2, 6> func_approx_2d(&input, center2d.data(), hl.data());
 
         // time_function<2>(func_approx_2d.f_, x_2d_transformed, 1);
         time_function<2>(func_approx_2d, x_2d_transformed, n_runs);

--- a/examples/fortran_example.f90
+++ b/examples/fortran_example.f90
@@ -1,25 +1,25 @@
 program main
   use baobzi
   implicit none
-  type(c_funptr) :: func
   real(kind=c_double) :: center(2), half_length(2), tol
   real(kind=c_double) :: x(2)
-  integer(kind=c_int16_t) :: order, dim
-  type(c_ptr) :: func_approx
   character(len=64) :: fname
+  type(c_ptr) :: func_approx
+  type(baobzi_input_t) :: input
 
-  func = c_funloc(testfun)
+  input%func = c_funloc(testfun)
+  input%dim = 2
+  input%order = 6
+  input%tol = 1E-8
+
   center(:) = 0.0
   half_length(:) = 1.0
-  tol = 1E-8
-  dim = 2
-  order = 6
 
   x(:) = 0.25
 
   fname = trim(adjustl('fortran.baobzi'))//char(0)
 
-  func_approx = baobzi_init(func, dim, order, center, half_length, tol)
+  func_approx = baobzi_init(input, center, half_length)
   print *, baobzi_eval(func_approx, x) - testfun(x)
 
   call baobzi_save(func_approx, fname)

--- a/examples/fortran_example.f90
+++ b/examples/fortran_example.f90
@@ -1,16 +1,20 @@
 program main
   use baobzi
   implicit none
-  real(kind=c_double) :: center(2), half_length(2), tol, dummy
+  real(kind=c_double) :: center(2), half_length(2), tol
   real(kind=c_double) :: x(2)
+  real(kind=c_double), target :: scale_factor
   character(len=64) :: fname
   type(c_ptr) :: func_approx
   type(baobzi_input_t) :: input
 
   input%func = c_funloc(testfun)
+  input%data = c_loc(scale_factor)
   input%dim = 2
   input%order = 6
   input%tol = 1E-8
+
+  scale_factor = 1.0
 
   center(:) = 0.0
   half_length(:) = 1.0
@@ -20,13 +24,13 @@ program main
   fname = trim(adjustl('fortran.baobzi'))//char(0)
 
   func_approx = baobzi_init(input, center, half_length)
-  print *, baobzi_eval(func_approx, x) - testfun(x, dummy)
+  print *, baobzi_eval(func_approx, x) - testfun(x, scale_factor)
 
   call baobzi_save(func_approx, fname)
   func_approx = baobzi_free(func_approx)
 
   func_approx = baobzi_restore(fname)
-  print *, baobzi_eval(func_approx, x) - testfun(x, dummy)
+  print *, baobzi_eval(func_approx, x) - testfun(x, scale_factor)
 
 contains
   function testfun (x, data) bind(c) result(y)
@@ -36,7 +40,7 @@ contains
     real(kind=c_double) :: data
     real(kind=c_double) :: y
 
-    y = x(1) * x(2)
+    y = data * x(1) * x(2)
   end function testfun
 
 end program main

--- a/examples/fortran_example.f90
+++ b/examples/fortran_example.f90
@@ -1,7 +1,7 @@
 program main
   use baobzi
   implicit none
-  real(kind=c_double) :: center(2), half_length(2), tol
+  real(kind=c_double) :: center(2), half_length(2), tol, dummy
   real(kind=c_double) :: x(2)
   character(len=64) :: fname
   type(c_ptr) :: func_approx
@@ -20,19 +20,20 @@ program main
   fname = trim(adjustl('fortran.baobzi'))//char(0)
 
   func_approx = baobzi_init(input, center, half_length)
-  print *, baobzi_eval(func_approx, x) - testfun(x)
+  print *, baobzi_eval(func_approx, x) - testfun(x, dummy)
 
   call baobzi_save(func_approx, fname)
   func_approx = baobzi_free(func_approx)
 
   func_approx = baobzi_restore(fname)
-  print *, baobzi_eval(func_approx, x) - testfun(x)
+  print *, baobzi_eval(func_approx, x) - testfun(x, dummy)
 
 contains
-  function testfun (x) bind(c) result(y)
+  function testfun (x, data) bind(c) result(y)
     use, intrinsic :: iso_c_binding
     implicit none
     real(kind=c_double), dimension(*) :: x
+    real(kind=c_double) :: data
     real(kind=c_double) :: y
 
     y = x(1) * x(2)

--- a/include/baobzi.h
+++ b/include/baobzi.h
@@ -1,8 +1,8 @@
 #ifndef BAOBZI_H
 #define BAOBZI_H
 
-#include "baobzi/macros.h"
 #include "baobzi/header.h"
+#include "baobzi/macros.h"
 
 #include <stdint.h>
 
@@ -16,17 +16,16 @@ extern "C" {
 /// Contains pointers to the wrappers of the relevant template C++ functions for a
 /// dim+order+instruction set
 typedef struct {
-    void *obj; ///< Actual baobzi::Function object
-    int DIM; ///< Dimension of our function
-    int ORDER; ///< Order of the polynomial
-    double (*f_)(const double *); ///< Function our approximator represents
+    void *obj;                                    ///< Actual baobzi::Function object
+    int DIM;                                      ///< Dimension of our function
+    int ORDER;                                    ///< Order of the polynomial
     double (*eval)(const void *, const double *); ///< Pointer to evaluation function
-    void (*save)(const void *, const char *); ///< Pointer to save function
-    void (*free)(void *); ///< pointer to save function
+    void (*save)(const void *, const char *);     ///< Pointer to save function
+    void (*free)(void *);                         ///< pointer to save function
 } baobzi_struct;
 
 /// Our type for the C API
-typedef baobzi_struct* baobzi_t;
+typedef baobzi_struct *baobzi_t;
 
 /// @brief eval approximator at point x
 /// @param[in] func initialized C baobzi object
@@ -56,8 +55,7 @@ baobzi_t baobzi_free(baobzi_t func);
 /// @param[in] half_length [dim] half the size of the domain in each dimension
 /// @param[in] tol desired relative tolerance
 /// @returns initialized baobzi C object
-baobzi_t baobzi_init(double (*)(const double *), uint16_t dim, uint16_t order, const double *center,
-                     const double *half_length, const double tol);
+baobzi_t baobzi_init(const baobzi_input_t *input, const double *center, const double *half_length);
 
 /// @brief read dim/order/version info from file
 /// @param[in] fname path to input file

--- a/include/baobzi.h
+++ b/include/baobzi.h
@@ -27,6 +27,8 @@ typedef struct {
 /// Our type for the C API
 typedef baobzi_struct *baobzi_t;
 
+extern const baobzi_input_t baobzi_input_default;
+
 /// @brief eval approximator at point x
 /// @param[in] func initialized C baobzi object
 /// @param[in] x point to evaluate at

--- a/include/baobzi.hpp
+++ b/include/baobzi.hpp
@@ -17,9 +17,8 @@ class Baobzi {
     /// @param[in] center [dim] center of the domain
     /// @param[in] half_length [dim] half the size of the domain in each dimension
     /// @param[in] tol desired relative tolerance
-    Baobzi(double (*fin)(const double *), uint16_t dim, uint16_t order, const double *center, const double *half_length,
-           const double tol)
-        : obj_(baobzi_init(fin, dim, order, center, half_length, tol)) {}
+    Baobzi(const baobzi_input_t *input, const double *center, const double *half_length)
+        : obj_(baobzi_init(input, center, half_length)) {}
 
     /// @brief Restore baobzi object from serialized version
     /// @param[in] input_file path to file of serialized function

--- a/include/baobzi/header.h
+++ b/include/baobzi/header.h
@@ -3,9 +3,18 @@
 
 #define BAOBZI_HEADER_VERSION 0
 
+typedef double (*baobzi_input_func_t)(const double *, const void *);
+
+typedef struct {
+    baobzi_input_func_t func;
+    void *data;
+    int dim;
+    int order;
+    double tol;
+} baobzi_input_t;
+
 #ifdef BAOBZI_TEMPLATE_HPP
 #include <msgpack.hpp>
-
 struct baobzi_header_t {
     int dim;
     int order;
@@ -15,11 +24,10 @@ struct baobzi_header_t {
 #else
 /// @brief header for serialization
 typedef struct {
-    int dim; ///< Dimension of function
-    int order; ///< Order of polynomial
+    int dim;     ///< Dimension of function
+    int order;   ///< Order of polynomial
     int version; ///< Version of output format (BAOBZI_HEADER_VERSION)
 } baobzi_header_t;
 #endif
-
 
 #endif

--- a/include/baobzi/macros.h
+++ b/include/baobzi/macros.h
@@ -5,7 +5,7 @@
 
 #define BAOBZI_CASE(DIM, ORDER, ISET)                                                                                  \
     case BAOBZI_JOIN(DIM, ORDER, ISET): {                                                                              \
-        res->obj = baobzi_init_##DIM##d_##ORDER##_##ISET(fin, center, half_length, tol);                               \
+        res->obj = baobzi_init_##DIM##d_##ORDER##_##ISET(input, center, half_length);                                  \
         res->save = &baobzi_save_##DIM##d_##ORDER##_##ISET;                                                            \
         res->eval = &baobzi_eval_##DIM##d_##ORDER##_##ISET;                                                            \
         res->free = &baobzi_free_##DIM##d_##ORDER##_##ISET;                                                            \
@@ -16,7 +16,6 @@
     case BAOBZI_JOIN(DIM, ORDER, ISET): {                                                                              \
         baobzi::Function<DIM, ORDER, ISET> *f_ptr = new baobzi::Function<DIM, ORDER, ISET>();                          \
         *f_ptr = obj.as<baobzi::Function<DIM, ORDER, ISET>>();                                                         \
-        f_ptr->f_ = fin;                                                                                               \
         res->obj = f_ptr;                                                                                              \
         res->save = &baobzi_save_##DIM##d_##ORDER##_##ISET;                                                            \
         res->eval = &baobzi_eval_##DIM##d_##ORDER##_##ISET;                                                            \
@@ -32,16 +31,16 @@
         (*(baobzi::Function<DIM, ORDER, ISET> *)f).save(filename);                                                     \
     }                                                                                                                  \
     void baobzi_free_##DIM##d_##ORDER##_##ISET(void *f) { delete (baobzi::Function<DIM, ORDER, ISET> *)f; }            \
-    void *baobzi_init_##DIM##d_##ORDER##_##ISET(double (*fin)(const double *), const double *center,                   \
-                                                const double *half_length, const double tol) {                         \
-        return (void *)new baobzi::Function<DIM, ORDER, ISET>(fin, center, half_length, tol);                          \
+    void *baobzi_init_##DIM##d_##ORDER##_##ISET(const baobzi_input_t *input, const double *center,                     \
+                                                const double *half_length) {                                           \
+        return (void *)new baobzi::Function<DIM, ORDER, ISET>(input, center, half_length);                             \
     }
 
 #define BAOBZI_DECLS(DIM, ORDER, ISET)                                                                                 \
     double baobzi_eval_##DIM##d_##ORDER##_##ISET(const void *f, const double *x);                                      \
     void baobzi_save_##DIM##d_##ORDER##_##ISET(const void *f, const char *filename);                                   \
     void baobzi_free_##DIM##d_##ORDER##_##ISET(void *f);                                                               \
-    void *baobzi_init_##DIM##d_##ORDER##_##ISET(double (*)(const double *), const double *center,                      \
-                                                const double *half_length, const double tol);
+    void *baobzi_init_##DIM##d_##ORDER##_##ISET(const baobzi_input_t *input, const double *center,                     \
+                                                const double *half_length);
 
 #endif

--- a/python/src/baobzi.py
+++ b/python/src/baobzi.py
@@ -64,8 +64,7 @@ class Baobzi:
                 )
             self.dim = dim
             self.order = order
-            inputdata = BAOBZI_INPUT_STRUCT(INPUT_FUNC(fin), None, dim, order,
-                                            tol)
+            inputdata = BAOBZI_INPUT_STRUCT(INPUT_FUNC(fin), None, dim, order, tol)
 
             self.ptr = baobzi_init(pointer(inputdata),
                                    (c_double * dim)(*center),

--- a/src/baobzi.cpp
+++ b/src/baobzi.cpp
@@ -84,8 +84,6 @@ baobzi_t baobzi_restore(const char *filename_cstr) {
     msgpack::unpack(oh, infile.addr, infile.buflen, offset);
     msgpack::object obj = oh.get();
 
-    double (*fin)(const double *) = nullptr;
-    res->f_ = fin;
     res->DIM = header.dim;
     res->ORDER = header.order;
 
@@ -110,20 +108,18 @@ baobzi_t baobzi_free(baobzi_t func) {
     return nullptr;
 }
 
-baobzi_t baobzi_init(double (*fin)(const double *), uint16_t dim, uint16_t order, const double *center,
-                     const double *half_length, const double tol) {
+baobzi_t baobzi_init(const baobzi_input_t *input, const double *center, const double *half_length) {
     baobzi_t res = (baobzi_t)malloc(sizeof(baobzi_struct));
-    res->f_ = fin;
-    res->DIM = dim;
-    res->ORDER = order;
+    res->DIM = input->dim;
+    res->ORDER = input->order;
 
     int iset = get_iset();
 
-    switch (BAOBZI_JOIN(dim, order, iset)) {
+    switch (BAOBZI_JOIN(res->DIM, res->ORDER, iset)) {
 #include "baobzi/baobzi_cases.h"
     default: {
-        std::cerr << "BAOBZI ERROR: Unable to initialize Baobzi function with variables (DIM, ORDER): (" << dim << ", "
-                  << order << ")\n";
+        std::cerr << "BAOBZI ERROR: Unable to initialize Baobzi function with variables (DIM, ORDER): (" << res->DIM
+                  << ", " << res->ORDER << ")\n";
         break;
     }
     }

--- a/src/baobzi.f90
+++ b/src/baobzi.f90
@@ -2,13 +2,20 @@ module baobzi
   use, intrinsic :: iso_c_binding
   implicit none
 
+  type, bind(c) :: baobzi_input_t
+    type(c_funptr) :: func
+    type(c_ptr) :: data
+    integer(c_int) :: dim
+    integer(c_int) :: order
+    real(c_double) :: tol
+  end type baobzi_input_t
+
   interface
-    function baobzi_init (fin, dim, order, center, half_length, tol) bind(c) result(func)
+    function baobzi_init (input, center, half_length) bind(c) result(func)
       use, intrinsic :: iso_c_binding
-      type(c_funptr), intent(in), value :: fin
-      integer(kind=c_int16_t), intent(in), value :: dim, order
+      import :: baobzi_input_t
+      type(baobzi_input_t), intent(in) :: input
       real(kind=c_double), dimension(*) :: center, half_length
-      real(kind=c_double), intent(in), value :: tol
       type(c_ptr) :: func
     end function baobzi_init
 

--- a/src/baobzi.f90
+++ b/src/baobzi.f90
@@ -3,11 +3,11 @@ module baobzi
   implicit none
 
   type, bind(c) :: baobzi_input_t
-    type(c_funptr) :: func
-    type(c_ptr) :: data
-    integer(c_int) :: dim
-    integer(c_int) :: order
-    real(c_double) :: tol
+    type(c_funptr) :: func = c_null_funptr
+    type(c_ptr) :: data = c_null_ptr
+    integer(c_int) :: dim = 0
+    integer(c_int) :: order = 0
+    real(c_double) :: tol = 0
   end type baobzi_input_t
 
   interface

--- a/tests/test_c.cpp
+++ b/tests/test_c.cpp
@@ -3,30 +3,33 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 
-double testfun_2d(const double *x) { return exp(cos(5.0 * x[0]) * sin(5.0 * x[1])); }
+double testfun_2d(const double *x, const void *data) { return exp(cos(5.0 * x[0]) * sin(5.0 * x[1])); }
 
 TEST_CASE("2D evaluations", "[baobzi]") {
-    const int dim = 2;
-    const int order = 6;
-    const double tol = 1E-10;
+    baobzi_input_t input;
+    input.dim = 2;
+    input.order = 6;
+    input.tol = 1E-10;
+    input.func = testfun_2d;
     const double half_l[2] = {M_PI / 5, M_PI / 5};
     const double center[2] = {-10.0, 3.0};
+    const void *data = nullptr;
 
-    baobzi_t baobzi_func = baobzi_init(testfun_2d, dim, order, center, half_l, tol);
+    baobzi_t baobzi_func = baobzi_init(&input, center, half_l);
 
     SECTION("evaluations at lower left") {
         double x[2] = {center[0] - half_l[0], center[1] - half_l[1]};
         double y_appx = baobzi_eval(baobzi_func, x);
-        double y_exact = baobzi_func->f_(x);
+        double y_exact = testfun_2d(x, data);
 
-        REQUIRE(fabs((y_appx - y_exact) / y_exact) < tol);
+        REQUIRE(fabs((y_appx - y_exact) / y_exact) < input.tol);
     }
 
     SECTION("evaluations at center") {
         double y_appx = baobzi_eval(baobzi_func, center);
-        double y_exact = baobzi_func->f_(center);
+        double y_exact = testfun_2d(center, data);
 
-        REQUIRE(fabs((y_appx - y_exact) / y_exact) < tol);
+        REQUIRE(fabs((y_appx - y_exact) / y_exact) < input.tol);
     }
 
     SECTION("save/restore") {


### PR DESCRIPTION
Should fix the API to be more static. Adding more features will change the struct, rather than the function signatures. As of now, all the bindings use the struct internally, but the user API hasn't changed yet for a few of the languages. Will need to work out the best way to handle this in other languages.

The main current benefit of this PR is that the user now has a means to provide a function with an arbitrary parameter payload. This worked fine in Julia/Python, since their functions had the payloads already attached. MATLAB/C/C++/Fortran however don't. C++ could support something like std::function, but because the C++ API is more easily written as a a thin layer around the C API, using the old style `void *` data payload approach is preferred.

- [x] C user-facing struct
- [x] Fortran user-facing struct
- [x] C++ user-facing struct
- [ ] ~Julia user-facing struct~
- [ ] ~MATLAB user-facing struct~
- [ ] ~Python user-facing struct~
- [ ] ~MATLAB data payload (or anonymous functions) - might not be pertinent here~
